### PR TITLE
Add uvisor unsupported target.

### DIFF
--- a/include/uvisor/api/inc/unsupported.h
+++ b/include/uvisor/api/inc/unsupported.h
@@ -64,6 +64,8 @@ UVISOR_EXTERN const uint32_t __uvisor_mode;
 
 #define UVISOR_BOX_CONFIG_CTX(...) UVISOR_BOX_CONFIG(__VA_ARGS__)
 
+#define UVISOR_BOX_NAMESPACE(...)
+
 /* uvisor-lib/interrupts.h */
 
 #define vIRQ_SetVector(irqn, vector)        NVIC_SetVector((IRQn_Type) (irqn), (uint32_t) (vector))

--- a/source/unsupported.c
+++ b/source/unsupported.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "uvisor-lib/uvisor-lib.h"
+
+#if !(defined(UVISOR_PRESENT) && (UVISOR_PRESENT == 1))
+
+/* Note: This file is not included in the uVisor release library. Instead, the
+ *       host OS needs to compile it separately if a platform does not support
+ *       uVisor (but uVisor API header files are still used). */
+
+/* uVisor hook for unsupported platforms */
+UVISOR_EXTERN void uvisor_init(void)
+{
+    return;
+}
+
+#endif


### PR DESCRIPTION
This adds an empty `uvisor_init` implementation which is chosen when `UVISOR_PRESENT` is not defined or set to zero.

cc @patater @meriac @AlessandroA 